### PR TITLE
feat: improve error messages for unresolved refs and allow arguments to be implemented after references

### DIFF
--- a/packages/converter/CHANGELOG.md
+++ b/packages/converter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 1.4.1-alpha.0 - 2021-01-23
+
+**Note:** Version bump only for package @giraphql/converter
+
+
+
+
+
 ### 1.4.0 - 2021-01-11
 
 **Note:** Version bump only for package @giraphql/converter

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giraphql/converter",
-  "version": "1.4.0",
+  "version": "1.4.1-alpha.0",
   "description": "A converter for generating GiraphQL SchemaBuilder code from GraphQL SDL",
   "main": "lib/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@giraphql/core": "^1.4.0",
+    "@giraphql/core": "^1.5.0-alpha.0",
     "@types/yargs": "^15.0.12"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.5.0-alpha.0 - 2021-01-23
+
+#### 🚀 Updates
+
+- improve error messages for unresolved refs and allow arguments to be implemented after references ([8c5a8b0](https://github.com/hayes/giraphql/commit/8c5a8b0))
+
+**Note:** Version bump only for package @giraphql/core
+
+
+
+
+
 ### 1.4.0 - 2021-01-11
 
 **Note:** Version bump only for package @giraphql/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giraphql/core",
-  "version": "1.4.0",
+  "version": "1.5.0-alpha.0",
   "description": "GiraphQL is a plugin based schema builder for creating code-first GraphQL schemas in typescript",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/fieldUtils/input.ts
+++ b/packages/core/src/fieldUtils/input.ts
@@ -56,10 +56,12 @@ export default class InputFieldBuilder<
   field<Type extends InputType<Types> | [InputType<Types>], Req extends FieldRequiredness<Type>>(
     options: GiraphQLSchemaTypes.InputFieldOptions<Types, Type, Req>,
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const ref: InputFieldRef<InputShapeFromTypeParam<Types, Type, Req>, Kind> = {} as any;
+    const ref: InputFieldRef<InputShapeFromTypeParam<Types, Type, Req>, Kind> = new InputFieldRef(
+      this.kind,
+      this.typename,
+    );
 
-    this.builder.configStore.addFieldRef(ref, options.type, (name) => ({
+    this.builder.configStore.addFieldRef(ref, options.type, {}, (name) => ({
       name,
       kind: this.kind,
       graphqlKind: this.kind,

--- a/packages/core/src/refs/field.ts
+++ b/packages/core/src/refs/field.ts
@@ -3,13 +3,22 @@ import { outputFieldShapeKey, FieldKind } from '../types';
 export default class FieldRef<T = unknown, Kind extends FieldKind = FieldKind> {
   kind: FieldKind;
 
+  parentTypename: string;
+
+  fieldName?: string;
+
   [outputFieldShapeKey]: T;
 
-  constructor(kind: Kind) {
+  constructor(kind: Kind, parentTypename: string) {
     this.kind = kind;
+    this.parentTypename = parentTypename;
   }
 
   toString() {
-    return `${this.kind}FieldRef`;
+    if (this.fieldName) {
+      return `${this.parentTypename}.${this.fieldName}`;
+    }
+
+    return this.parentTypename;
   }
 }

--- a/packages/core/src/refs/input-field.ts
+++ b/packages/core/src/refs/input-field.ts
@@ -1,3 +1,4 @@
+import { FieldRef } from '..';
 import { inputFieldShapeKey } from '../types';
 
 export default class InputFieldRef<
@@ -6,13 +7,30 @@ export default class InputFieldRef<
 > {
   kind: 'InputObject' | 'Arg';
 
+  parentTypename: string;
+
+  fieldName?: string;
+
+  argFor?: InputFieldRef | FieldRef;
+
   [inputFieldShapeKey]: T;
 
-  constructor(kind: Kind) {
+  constructor(kind: Kind, parentTypename: string) {
     this.kind = kind;
+    this.parentTypename = parentTypename;
   }
 
   toString() {
-    return `${this.kind}FieldRef`;
+    if (this.kind !== 'Arg') {
+      if (this.fieldName) {
+        return `${this.parentTypename}.${this.fieldName}`;
+      }
+
+      return this.parentTypename;
+    }
+    const fieldName = this.argFor?.fieldName || '[unnamed filed]';
+    const argName = this.fieldName || '[unnamed argument]';
+
+    return `${this.parentTypename}.${fieldName}(${argName})`;
   }
 }


### PR DESCRIPTION
fixes #22 

Previously when using TS enums for types or arguments, if the GraphQL type was not implemented, the error message would not be very helpful.

TS enums do not have names at runtime, and without an implementation naming them is not possible.  Instead, this change will track some additional information about the names of field references so that the generated errors can point at a more specific issues.

Example error after this change when enum is used as an arugment:
```
Error: Missing implementations for some references (<unnamed ref or enum: used by Giraffe.foo(arg1)>).
    at ConfigStore.prepareForBuild (/Users/michael.hayes/code/giraphql/packages/core/src/config-store.ts:354:13)
    at SchemaBuilder.toSchema (/Users/michael.hayes/code/giraphql/packages/core/src/builder.ts:537:22)
```
Example error after this change when enum is used in a type parameter:

```
Error: Missing implementations for some references (<unnamed ref or enum: used by Giraffe.foo>).
    at ConfigStore.prepareForBuild (/Users/michael.hayes/code/giraphql/packages/core/src/config-store.ts:354:13)
    at SchemaBuilder.toSchema (/Users/michael.hayes/code/giraphql/packages/core/src/builder.ts:537:22)
```


The other significant change here is that the build cache is more aware of arguments, and will not try to build fields until the argument fields are all resolved (the implementation for the types used in arguments are added). 

This fixes the case where an argument uses an enum type who's implementation is added later in the file, or in a file imported after the current file.