### PR TITLE
More doc fixes

### DIFF
--- a/docs/guide/enums.md
+++ b/docs/guide/enums.md
@@ -19,15 +19,15 @@ Enums can be defined a number of different ways:
    }
 
    builder.enumType(Diet, {
-     name: "Diet",
+     name: 'Diet',
    });
    ```
 
 1. Using an array of strings
 
    ```typescript
-   export const LengthUnit = builder.enumType("LengthUnit", {
-     values: ["Feet", "Meters"] as const,
+   export const LengthUnit = builder.enumType('LengthUnit', {
+     values: ['Feet', 'Meters'] as const,
    });
    ```
 
@@ -36,20 +36,20 @@ Enums can be defined a number of different ways:
 1. Using a values object:
 
    ```typescript
-   export const GiraffeSpecies = builder.enumType("GiraffeSpecies", {
+   export const GiraffeSpecies = builder.enumType('GiraffeSpecies', {
      values: {
        Southern: {
-         description: "Also known as two-horned giraffe",
-         value: "giraffa",
+         description: 'Also known as two-horned giraffe',
+         value: 'giraffa',
        },
        Masai: {
-         value: "tippelskirchi",
+         value: 'tippelskirchi',
        },
        Reticulated: {
-         value: "reticulata",
+         value: 'reticulata',
        },
        Northern: {
-         value: "camelopardalis",
+         value: 'camelopardalis',
        },
      } as const,
    });
@@ -65,29 +65,29 @@ Enums can be defined a number of different ways:
 Enums can be references either by the `Ref` that was returned by calling `builder.enumType` or by using the typescript enum. They can be used either as arguments, or as field return types:
 
 ```typescript
-builder.objectFields("Giraffe", (t) => ({
+builder.objectFields('Giraffe', (t) => ({
   height: t.float({
     args: {
       unit: t.arg({
         type: LengthUnit,
         required: true,
-        defaultValue: "Meters",
+        defaultValue: 'Meters',
       }),
     },
     resolve: (parent, args) =>
-      args.unit === "Meters"
+      args.unit === 'Meters'
         ? parent.heightInMeters
         : parent.heightInMeters * 3.281,
   }),
   diet: t.field({
     description:
-      "While Giraffes are herbivores, they do eat the bones of dead animals to get extra calcium",
+      'While Giraffes are herbivores, they do eat the bones of dead animals to get extra calcium',
     type: Diet,
     resolve: () => Diet.HERBIVOROUS,
   }),
   species: t.field({
     type: GiraffeSpecies,
-    resolve: () => "camelopardalis" as const,
+    resolve: () => 'camelopardalis' as const,
   }),
 }));
 ```

--- a/docs/guide/enums.md
+++ b/docs/guide/enums.md
@@ -11,84 +11,83 @@ Enums can be defined a number of different ways:
 
 1. Using typescript enums
 
-```typescript
-export enum Diet {
-  HERBIVOROUS,
-  CARNIVOROUS,
-  OMNIVORIOUS,
-}
+   ```typescript
+   export enum Diet {
+     HERBIVOROUS,
+     CARNIVOROUS,
+     OMNIVORIOUS,
+   }
 
-builder.enumType(Diet, {
-  name: 'Diet',
-});
-```
+   builder.enumType(Diet, {
+     name: "Diet",
+   });
+   ```
 
 1. Using an array of strings
 
-```typescript
-export const LengthUnit = builder.enumType('LengthUnit', {
-  values: ['Feet', 'Meters'] as const,
-});
-```
+   ```typescript
+   export const LengthUnit = builder.enumType("LengthUnit", {
+     values: ["Feet", "Meters"] as const,
+   });
+   ```
 
-Note that we use `as const` to allow ts to properly type our enum values.
+   Note that we use `as const` to allow ts to properly type our enum values.
 
 1. Using a values object:
 
-```typescript
-export const GiraffeSpecies = builder.enumType('GiraffeSpecies', {
-  values: {
-    Southern: {
-      description: 'Also known as two-horned giraffe',
-      value: 'giraffa',
-    },
-    Masai: {
-      value: 'tippelskirchi',
-    },
-    Reticulated: {
-      value: 'reticulata',
-    },
-    Northern: {
-      value: 'camelopardalis',
-    },
-  } as const,
-});
-```
+   ```typescript
+   export const GiraffeSpecies = builder.enumType("GiraffeSpecies", {
+     values: {
+       Southern: {
+         description: "Also known as two-horned giraffe",
+         value: "giraffa",
+       },
+       Masai: {
+         value: "tippelskirchi",
+       },
+       Reticulated: {
+         value: "reticulata",
+       },
+       Northern: {
+         value: "camelopardalis",
+       },
+     } as const,
+   });
+   ```
 
-Again we use `as const` here to allow the enum values to be correctly inferred. The `as const` can
-also be added to the values instead, or omitted if the `values` already are defined using a variable
-that typescript can type correctly.
+   Again we use `as const` here to allow the enum values to be correctly inferred.
+   The `as const` can also be added to the values instead, or omitted if the `values` already are defined using a variable that typescript can type correctly.
 
-Using a values object like this enables defining additional options like a description for each enum
-value.
+   Using a values object like this enables defining additional options like a description for each enum value.
 
 ## Using Enum Types
 
-Enums can be references either by the `Ref` that was returned by calling `builder.enumType` or by
-using the typescript enum. They can be used either as arguments, or as field return types:
+Enums can be references either by the `Ref` that was returned by calling `builder.enumType` or by using the typescript enum. They can be used either as arguments, or as field return types:
 
 ```typescript
-builder.objectFields('Giraffe', (t) => ({
+builder.objectFields("Giraffe", (t) => ({
   height: t.float({
     args: {
       unit: t.arg({
         type: LengthUnit,
         required: true,
-        defaultValue: 'Meters',
+        defaultValue: "Meters",
       }),
     },
     resolve: (parent, args) =>
-      args.unit === 'Meters' ? parent.heightInMeters : parent.heightInMeters * 3.281,
+      args.unit === "Meters"
+        ? parent.heightInMeters
+        : parent.heightInMeters * 3.281,
   }),
   diet: t.field({
     description:
-      'While Giraffes are herbivores, they do eat the bones of dead animals to get extra calcium',
+      "While Giraffes are herbivores, they do eat the bones of dead animals to get extra calcium",
     type: Diet,
     resolve: () => Diet.HERBIVOROUS,
   }),
   species: t.field({
     type: GiraffeSpecies,
-    resolve: () => 'camelopardalis' as const,
+    resolve: () => "camelopardalis" as const,
   }),
 }));
 ```

--- a/docs/guide/enums.md
+++ b/docs/guide/enums.md
@@ -62,7 +62,8 @@ Enums can be defined a number of different ways:
 
 ## Using Enum Types
 
-Enums can be references either by the `Ref` that was returned by calling `builder.enumType` or by using the typescript enum. They can be used either as arguments, or as field return types:
+Enums can be references either by the `Ref` that was returned by calling `builder.enumType` or by using the typescript enum. 
+They can be used either as arguments, or as field return types:
 
 ```typescript
 builder.objectFields('Giraffe', (t) => ({


### PR DESCRIPTION
1. Lists where showing 1./1./1. because of the breaks caused by the code examples.
1. Arbitrary line breaks in paragraphs
