### PR TITLE
Make relay connection args optional explicitly

### DIFF
--- a/packages/plugin-relay/src/field-builder.ts
+++ b/packages/plugin-relay/src/field-builder.ts
@@ -194,10 +194,10 @@ fieldBuilderProto.connection = function connection(
     type: placeholderRef,
     args: {
       ...fieldOptions.args,
-      before: this.arg.id({}),
-      after: this.arg.id({}),
-      first: this.arg.int({}),
-      last: this.arg.int({}),
+      before: this.arg.id({ required: false }),
+      after: this.arg.id({ required: false }),
+      first: this.arg.int({ required: false }),
+      last: this.arg.int({ required: false }),
     },
     resolve: fieldOptions.resolve as never,
   });


### PR DESCRIPTION
I'm like 90% sure this was the correct place to make this change but if not please let me know 😄 

Fixes #64 