### PR TITLE
docs(plugins/dataloader): copy paste mistake

### DIFF
--- a/docs/plugins/dataloader.md
+++ b/docs/plugins/dataloader.md
@@ -12,7 +12,7 @@ This plugin makes it easy to add fields and types that are loaded through a data
 ### Install
 
 To use the dataloader plugin you will need to install both the `dataloader` package and the
-validation plugin:
+giraphql dataloader plugin:
 
 ```bash
 yarn add dataloader @giraphql/plugin-dataloader


### PR DESCRIPTION
The validation plugin is not necessary for the dataloader package. This was probably a copy + paste mistake from the validation plugin docs.