### PR TITLE
Use Uncapitalize instead of Lowercase for prisma. 

### DIFF
--- a/.changeset/few-houses-raise.md
+++ b/.changeset/few-houses-raise.md
@@ -1,0 +1,5 @@
+---
+'@giraphql/plugin-prisma': patch
+---
+
+Fix prisma plugin for multi-word model names.

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -174,8 +174,8 @@ export type ModelName<Types extends SchemaTypes> = {
 export type DelegateFromName<
   Types extends SchemaTypes,
   Name extends ModelName<Types>,
-> = Lowercase<Name> extends keyof Types['PrismaClient']
-  ? Extract<Types['PrismaClient'][Lowercase<Name>], PrismaDelegate>
+> = Uncapitalize<Name> extends keyof Types['PrismaClient']
+  ? Extract<Types['PrismaClient'][Uncapitalize<Name>], PrismaDelegate>
   : never;
 
 export type QueryForField<Args extends InputFieldMap, Include> = Include extends { where?: unknown }


### PR DESCRIPTION
I found out that this was causing issues with PascalCase model names in Prisma. We really just need to convert the first letter to lowercase, not the entire model name.