### PR TITLE
feature: support refs and classes in dataloader objects

### DIFF
--- a/.changeset/lazy-dryers-listen.md
+++ b/.changeset/lazy-dryers-listen.md
@@ -1,0 +1,5 @@
+---
+'@giraphql/plugin-dataloader': minor
+---
+
+Add support for classes and object refs with dataloader objects

--- a/packages/plugin-dataloader/src/global-types.ts
+++ b/packages/plugin-dataloader/src/global-types.ts
@@ -4,8 +4,10 @@ import {
   FieldRef,
   InputFieldMap,
   InterfaceParam,
+  ObjectParam,
   PluginName,
   SchemaTypes,
+  ShapeFromTypeParam,
   TypeParam,
 } from '@giraphql/core';
 import { GiraphQLDataloaderPlugin } from './index.js';
@@ -20,24 +22,30 @@ declare global {
 
     export interface SchemaBuilder<Types extends SchemaTypes> {
       loadableObject: <
-        Shape extends object,
+        Shape extends NameOrRef extends ObjectParam<Types>
+          ? ShapeFromTypeParam<Types, NameOrRef, false>
+          : object,
         Key extends bigint | number | string,
         Interfaces extends InterfaceParam<Types>[],
+        NameOrRef extends ObjectParam<Types> | string,
         CacheKey = Key,
       >(
-        name: string,
-        options: DataloaderObjectTypeOptions<Types, Shape, Key, Interfaces, CacheKey>,
+        nameOrRef: NameOrRef,
+        options: DataloaderObjectTypeOptions<Types, Shape, Key, Interfaces, NameOrRef, CacheKey>,
       ) => Omit<LoadableObjectRef<Types, Key | Shape, Shape, Key, CacheKey>, 'implement'>;
 
       loadableNode: 'relay' extends PluginName
         ? <
-            Shape extends object,
+            Shape extends NameOrRef extends ObjectParam<Types>
+              ? ShapeFromTypeParam<Types, NameOrRef, false>
+              : object,
             Key extends bigint | number | string,
             Interfaces extends InterfaceParam<Types>[],
+            NameOrRef extends ObjectParam<Types> | string,
             CacheKey = Key,
           >(
-            name: string,
-            options: LoadableNodeOptions<Types, Shape, Key, Interfaces, CacheKey>,
+            nameOrRef: NameOrRef,
+            options: LoadableNodeOptions<Types, Shape, Key, Interfaces, NameOrRef, CacheKey>,
           ) => Omit<LoadableObjectRef<Types, Key | Shape, Shape, Key, CacheKey>, 'implement'>
         : '@giraphql/plugin-relay is required to use this method';
     }

--- a/packages/plugin-dataloader/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-dataloader/tests/__snapshots__/index.test.ts.snap
@@ -7,6 +7,11 @@ exports[`dataloader generates expected schema 1`] = `
   name: String!
 }
 
+type ClassLoadableThing implements Node & TestInterface {
+  id: ID!
+  idFromInterface: ID!
+}
+
 interface Node {
   id: ID!
 }
@@ -24,6 +29,8 @@ type Post {
 
 type Query {
   addOnUser: User!
+  classThing: ClassLoadableThing!
+  classThingRef: ClassLoadableThing!
   counts: [CallCount!]!
   fromContext1: User!
   fromContext2: User!

--- a/packages/plugin-dataloader/tests/example/schema/index.ts
+++ b/packages/plugin-dataloader/tests/example/schema/index.ts
@@ -17,6 +17,11 @@ function countCall(context: ContextType, getCounts: typeof usersCounts, loaded: 
   return group;
 }
 
+class ClassThing {
+  id: number = 123;
+  name: string = 'some name';
+}
+
 const TestInterface = builder.interfaceRef<{ id: number }>('TestInterface').implement({
   fields: (t) => ({
     idFromInterface: t.exposeID('id', {}),
@@ -52,6 +57,18 @@ const UserNode = builder.loadableNode('UserNode', {
       keys.map((id) => (Number(id) > 0 ? { id: Number(id) } : new Error(`Invalid ID ${id}`))),
     );
   },
+  fields: (t) => ({}),
+});
+
+const ClassThingRef = builder.loadableNode(ClassThing, {
+  name: 'ClassLoadableThing',
+  interfaces: [TestInterface],
+  id: {
+    resolve: (user) => user.id,
+  },
+  loaderOptions: { maxBatchSize: 20 },
+  // eslint-disable-next-line @typescript-eslint/require-await
+  load: async (keys: string[], context: ContextType) => [new ClassThing()],
   fields: (t) => ({}),
 });
 
@@ -252,6 +269,14 @@ builder.queryFields((t) => ({
       );
     },
     resolve: (_root, args) => Promise.resolve(args.ids),
+  }),
+  classThing: t.field({
+    type: ClassThing,
+    resolve: () => new ClassThing(),
+  }),
+  classThingRef: t.field({
+    type: ClassThingRef,
+    resolve: () => '1',
   }),
 }));
 

--- a/packages/plugin-dataloader/tests/index.test.ts
+++ b/packages/plugin-dataloader/tests/index.test.ts
@@ -77,6 +77,12 @@ describe('dataloader', () => {
           fromContext4 {
             id
           }
+          classThing {
+            id
+          }
+          classThingRef {
+            id
+          }
         }
       `;
 
@@ -89,6 +95,12 @@ describe('dataloader', () => {
       expect(result).toMatchInlineSnapshot(`
 Object {
   "data": Object {
+    "classThing": Object {
+      "id": "Q2xhc3NMb2FkYWJsZVRoaW5nOjEyMw==",
+    },
+    "classThingRef": Object {
+      "id": "Q2xhc3NMb2FkYWJsZVRoaW5nOjEyMw==",
+    },
     "counts": Array [
       Object {
         "calls": 1,


### PR DESCRIPTION
🦋  @giraphql/converter@0.0.0-preview-202178194614
🦋  @giraphql/core@0.0.0-preview-202178194614
🦋  @giraphql/deno@0.0.0-preview-202178194614
🦋  @giraphql/plugin-dataloader@0.0.0-preview-202178194614
🦋  @giraphql/plugin-directives@0.0.0-preview-202178194614
🦋  @giraphql/plugin-errors@0.0.0-preview-202178194614
🦋  @giraphql/plugin-example@0.0.0-preview-202178194614
🦋  @giraphql/plugin-mocks@0.0.0-preview-202178194614
🦋  @giraphql/plugin-prisma@0.0.0-preview-202178194614
🦋  @giraphql/plugin-relay@0.0.0-preview-202178194614
🦋  @giraphql/plugin-scope-auth@0.0.0-preview-202178194614
🦋  @giraphql/plugin-simple-objects@0.0.0-preview-202178194614
🦋  @giraphql/plugin-smart-subscriptions@0.0.0-preview-202178194614
🦋  @giraphql/plugin-sub-graph@0.0.0-preview-202178194614
🦋  @giraphql/plugin-validation@0.0.0-preview-202178194614