### PR TITLE
tests for validation on input

### DIFF
--- a/packages/plugin-validation/tests/example/schema/index.ts
+++ b/packages/plugin-validation/tests/example/schema/index.ts
@@ -243,6 +243,17 @@ const WithValidationInput = builder.inputType('WithValidationInput', {
     [(args) => args.age === 100, { message: 'Incorrect age given' }],
   ],
 });
+const WithValidationWorkingInput = builder.inputType('WithValidationWorkingInput', {
+  fields: (t) => ({
+    // When we add validate, it turns on validate for the input type
+    name: t.string({ validate: () => true }),
+    age: t.int(),
+  }),
+  validate: [
+    [(args) => args.name === 'secret', { message: 'Incorrect name given' }],
+    [(args) => args.age === 100, { message: 'Incorrect age given' }],
+  ],
+});
 
 const NestedInput = builder.inputType('NestedInput', {
   fields: (t) => ({ id: t.id() }),
@@ -292,11 +303,21 @@ builder.queryField('nestedObjectList', (t) =>
   }),
 );
 
-builder.queryField('getSecret', (t) =>
+builder.queryField('getSecretNotWorking', (t) =>
   t.boolean({
     nullable: true,
     args: {
       input: t.arg({ type: WithValidationInput }),
+    },
+    resolve: () => true,
+  }),
+);
+
+builder.queryField('getSecretWorking', (t) =>
+  t.boolean({
+    nullable: true,
+    args: {
+      input: t.arg({ type: WithValidationWorkingInput }),
     },
     resolve: () => true,
   }),

--- a/packages/plugin-validation/tests/example/schema/index.ts
+++ b/packages/plugin-validation/tests/example/schema/index.ts
@@ -236,8 +236,12 @@ builder.queryType({
 const WithValidationInput = builder.inputType('WithValidationInput', {
   fields: (t) => ({
     name: t.string(),
+    age: t.int(),
   }),
-  validate: [[(args) => args.name === 'secret', { message: 'Incorrect name given' }]],
+  validate: [
+    [(args) => args.name === 'secret', { message: 'Incorrect name given' }],
+    [(args) => args.age === 100, { message: 'Incorrect age given' }],
+  ],
 });
 
 const NestedInput = builder.inputType('NestedInput', {

--- a/packages/plugin-validation/tests/example/schema/index.ts
+++ b/packages/plugin-validation/tests/example/schema/index.ts
@@ -233,6 +233,13 @@ builder.queryType({
   }),
 });
 
+const WithValidationInput = builder.inputType('WithValidationInput', {
+  fields: (t) => ({
+    name: t.string(),
+  }),
+  validate: [[(args) => args.name === 'secret', { message: 'Incorrect name given' }]],
+});
+
 const NestedInput = builder.inputType('NestedInput', {
   fields: (t) => ({ id: t.id() }),
 });
@@ -276,6 +283,16 @@ builder.queryField('nestedObjectList', (t) =>
     nullable: true,
     args: {
       input: t.arg({ type: NestedObjectListInput }),
+    },
+    resolve: () => true,
+  }),
+);
+
+builder.queryField('getSecret', (t) =>
+  t.boolean({
+    nullable: true,
+    args: {
+      input: t.arg({ type: WithValidationInput }),
     },
     resolve: () => true,
   }),

--- a/packages/plugin-validation/tests/index.test.ts
+++ b/packages/plugin-validation/tests/index.test.ts
@@ -283,8 +283,6 @@ describe('validation', () => {
         valid: soloNested(input: { nested: { id: "12" } })
         invalidList: nestedObjectList(input: { nested: [{ id: "1" }] })
         validList: nestedObjectList(input: { nested: [{ id: "12" }] })
-        validI: getSecret(input: { name: "secret", age: 100 })
-        invalidI: getSecret(input: { name: "not secret", age: 101 })
       }
     `;
 
@@ -331,6 +329,33 @@ describe('validation', () => {
         }
       ]],
         ],
+      }
+    `);
+  });
+  it('input object with input', async () => {
+    const query = gql`
+      query {
+        getSecretNotWorkingValid: getSecretNotWorking(input: { name: "secret", age: 100 })
+        getSecretNotWorkingInvalid: getSecretNotWorking(input: { name: "not secret", age: 101 })
+        getSecretWorkingValid: getSecretWorking(input: { name: "secret", age: 100 })
+        getSecretWorkingInvalid: getSecretWorking(input: { name: "not secret", age: 101 })
+      }
+    `;
+
+    const result = await execute({
+      schema,
+      document: query,
+      contextValue: {},
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "getSecretNotWorkingValid": true,
+          "getSecretWorkingValid": true,
+          "getSecretNotWorkingInvalid": null,
+          "getSecretWorkingInvalid": null,
+        },
       }
     `);
   });

--- a/packages/plugin-validation/tests/index.test.ts
+++ b/packages/plugin-validation/tests/index.test.ts
@@ -283,6 +283,8 @@ describe('validation', () => {
         valid: soloNested(input: { nested: { id: "12" } })
         invalidList: nestedObjectList(input: { nested: [{ id: "1" }] })
         validList: nestedObjectList(input: { nested: [{ id: "12" }] })
+        validI: getSecret(input: { name: "secret" })
+        invalidI: getSecret(input: { name: "not secret" })
       }
     `;
 

--- a/packages/plugin-validation/tests/index.test.ts
+++ b/packages/plugin-validation/tests/index.test.ts
@@ -283,8 +283,8 @@ describe('validation', () => {
         valid: soloNested(input: { nested: { id: "12" } })
         invalidList: nestedObjectList(input: { nested: [{ id: "1" }] })
         validList: nestedObjectList(input: { nested: [{ id: "12" }] })
-        validI: getSecret(input: { name: "secret" })
-        invalidI: getSecret(input: { name: "not secret" })
+        validI: getSecret(input: { name: "secret", age: 100 })
+        invalidI: getSecret(input: { name: "not secret", age: 101 })
       }
     `;
 


### PR DESCRIPTION
hey @hayes! 

We ran into a validation plugin bug where:

1. if `validate` is on the input object, it does not run unless a `validate` is added to a field on the input object
2. validate can take an array of arrays, but only one is run and the last one (which if succeeds, the whole validation seems to succeed?)


Ad you can see, when we add `validate` to a field, it makes the validate on the input field work again, hence why there is an error in the response. Whereas, if the `validate` on the field is missing, no `validate` is run on the input object. 